### PR TITLE
Patch 0.15.0 - DO NOT MERGE

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled")
+load("//rust:defs.bzl", "capture_clippy_output", "clippy_flags", "error_format", "extra_exec_rustc_flag", "extra_exec_rustc_flags", "extra_rustc_flag", "extra_rustc_flags", "is_proc_macro_dep", "is_proc_macro_dep_enabled", "source_path_prefix")
 
 exports_files(["LICENSE"])
 
@@ -73,6 +73,15 @@ extra_exec_rustc_flags(
 extra_exec_rustc_flag(
     name = "extra_exec_rustc_flag",
     build_setting_default = "",
+    visibility = ["//visibility:public"],
+)
+
+# This setting may be used to override the prefix for source paths rustc embeds into build artifacts.
+# Setting this setting to a fixed value (e.g., "/source/") can help achieve reproducible builds and
+# improve cache utilization.
+source_path_prefix(
+    name = "source_path_prefix",
+    build_setting_default = ".",
     visibility = ["//visibility:public"],
 )
 

--- a/rust/defs.bzl
+++ b/rust/defs.bzl
@@ -49,6 +49,7 @@ load(
     _extra_rustc_flags = "extra_rustc_flags",
     _is_proc_macro_dep = "is_proc_macro_dep",
     _is_proc_macro_dep_enabled = "is_proc_macro_dep_enabled",
+    _source_path_prefix = "source_path_prefix",
 )
 load(
     "//rust/private:rustdoc.bzl",
@@ -122,6 +123,9 @@ is_proc_macro_dep = _is_proc_macro_dep
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 is_proc_macro_dep_enabled = _is_proc_macro_dep_enabled
+# See @rules_rust//rust/private:rustc.bzl for a complete description.
+
+source_path_prefix = _source_path_prefix
 # See @rules_rust//rust/private:rustc.bzl for a complete description.
 
 rust_common = _rust_common

--- a/rust/private/rust.bzl
+++ b/rust/private/rust.bzl
@@ -663,6 +663,9 @@ _common_attrs = {
     "_extra_rustc_flags": attr.label(
         default = Label("//:extra_rustc_flags"),
     ),
+    "_source_path_prefix": attr.label(
+        default = Label("//:source_path_prefix"),
+    ),
     "_import_macro_dep": attr.label(
         default = Label("//util/import"),
         cfg = "exec",

--- a/rust/private/rustdoc.bzl
+++ b/rust/private/rustdoc.bzl
@@ -120,7 +120,6 @@ def rustdoc_compile_action(
         build_env_files = build_env_files,
         build_flags_files = build_flags_files,
         emit = [],
-        remap_path_prefix = None,
         force_link = True,
         force_depend_on_objects = is_test,
     )

--- a/tools/rust_analyzer/aquery.rs
+++ b/tools/rust_analyzer/aquery.rs
@@ -4,6 +4,7 @@ use std::option::Option;
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
+use std::iter::FromIterator;
 
 use anyhow::Context;
 use serde::Deserialize;
@@ -162,40 +163,10 @@ fn path_from_fragments(
 
 /// Read all crate specs, deduplicating crates with the same ID. This happens when
 /// a rust_test depends on a rust_library, for example.
+/// GL: Currently this does nothing, because of situations in which cycles are encountered
+/// Upstream issue: https://github.com/bazelbuild/rules_rust/issues/1589
 fn consolidate_crate_specs(crate_specs: Vec<CrateSpec>) -> anyhow::Result<BTreeSet<CrateSpec>> {
-    let mut consolidated_specs: BTreeMap<String, CrateSpec> = BTreeMap::new();
-    for mut spec in crate_specs.into_iter() {
-        log::debug!("{:?}", spec);
-        if let Some(existing) = consolidated_specs.get_mut(&spec.crate_id) {
-            existing.deps.extend(spec.deps);
-
-            spec.cfg.retain(|cfg| !existing.cfg.contains(cfg));
-            existing.cfg.extend(spec.cfg);
-
-            // display_name should match the library's crate name because Rust Analyzer
-            // seems to use display_name for matching crate entries in rust-project.json
-            // against symbols in source files. For more details, see
-            // https://github.com/bazelbuild/rules_rust/issues/1032
-            if spec.crate_type == "rlib" {
-                existing.display_name = spec.display_name;
-                existing.crate_type = "rlib".into();
-            }
-
-            // For proc-macro crates that exist within the workspace, there will be a
-            // generated crate-spec in both the fastbuild and opt-exec configuration.
-            // Prefer proc macro paths with an opt-exec component in the path.
-            if let Some(dylib_path) = spec.proc_macro_dylib_path.as_ref() {
-                const OPT_PATH_COMPONENT: &str = "-opt-exec-";
-                if dylib_path.contains(OPT_PATH_COMPONENT) {
-                    existing.proc_macro_dylib_path.replace(dylib_path.clone());
-                }
-            }
-        } else {
-            consolidated_specs.insert(spec.crate_id.clone(), spec);
-        }
-    }
-
-    Ok(consolidated_specs.into_values().collect())
+    Ok(BTreeSet::from_iter(crate_specs))
 }
 
 #[cfg(test)]

--- a/version.bzl
+++ b/version.bzl
@@ -1,3 +1,3 @@
 """The version of rules_rust."""
 
-VERSION = "0.15.0"
+VERSION = "0.15.1"


### PR DESCRIPTION
This branch patches the rules rust 0.15.0 with DFINITY's changes.

This pull request's file changed shows a diff between patch-0.15.0 and upstream-0.15.0. You can also produce the diff with
```
git diff upstream-0.15.0 patch-0.15.0
```