### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
   validation:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       # TODO: Unfortunately it's not obvious how to restrict `workflow_dispatch` to a particular branch
       # so this step ensures releases are always done off of `main`.
       - name: Ensure branch is 'main'
@@ -69,7 +69,7 @@ jobs:
             env:
               TARGET: "x86_64-unknown-linux-musl"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Install rust toolchains for host
         run: |
           # Detect the current version of rust
@@ -101,7 +101,7 @@ jobs:
             bazel ${BAZEL_STARTUP_FLAGS[@]} run //crate_universe/tools/cross_installer -- --target=${TARGET} --output="${OUTPUT_PATH}"
         env:
           TARGET: "${{ matrix.env.TARGET }}"
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: "${{ matrix.env.TARGET }}"
           path: ${{ github.workspace }}/crate_universe/target/artifacts/${{ matrix.env.TARGET }}
@@ -110,8 +110,8 @@ jobs:
     needs: builds
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
+      - uses: actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1
         with:
           path: ${{ github.workspace }}/crate_universe/target/artifacts
       - name: Detect the current version
@@ -133,7 +133,7 @@ jobs:
           ARTIFACTS_DIR: ${{ github.workspace }}/crate_universe/target/artifacts
           URL_PREFIX: https://github.com/${{ github.repository_owner }}/rules_rust/releases/download/${{ env.RELEASE_VERSION }}
       # Upload the artifact in case creating a release fails so all artifacts can then be manually recovered.
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1
         with:
           name: "rules_rust.tar.gz"
           path: ${{ github.workspace }}/.github/rules_rust.tar.gz
@@ -145,7 +145,7 @@ jobs:
           | sed 's/{sha256}/${{ env.ARCHIVE_SHA256 }}/g' \
           > ${{ github.workspace }}/.github/release_notes.txt
       - name: Create release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         id: rules_rust_release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -156,7 +156,7 @@ jobs:
           target_commitish: ${{ github.base_ref }}
 
       - name: "Upload the rules archive"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -167,7 +167,7 @@ jobs:
 
       # There must be a upload action for each platform triple we create
       - name: "Upload aarch64-apple-darwin"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -176,7 +176,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/aarch64-apple-darwin/cargo-bazel
           asset_content_type: application/octet-stream
       - name: "Upload aarch64-pc-windows-msvc"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -185,7 +185,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/aarch64-pc-windows-msvc/cargo-bazel.exe
           asset_content_type: application/octet-stream
       - name: "Upload aarch64-unknown-linux-gnu"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -194,7 +194,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/aarch64-unknown-linux-gnu/cargo-bazel
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-apple-darwin"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -203,7 +203,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/x86_64-apple-darwin/cargo-bazel
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-pc-windows-gnu"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -212,7 +212,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/x86_64-pc-windows-gnu/cargo-bazel.exe
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-pc-windows-msvc"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -221,7 +221,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/x86_64-pc-windows-msvc/cargo-bazel.exe
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-unknown-linux-gnu"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -230,7 +230,7 @@ jobs:
           asset_path: ${{ github.workspace }}/crate_universe/target/artifacts/x86_64-unknown-linux-gnu/cargo-bazel
           asset_content_type: application/octet-stream
       - name: "Upload x86_64-unknown-linux-musl"
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Pin GitHub Actions to commit SHAs

GitHub Actions referenced by tag (e.g. `actions/checkout@v4`) use a mutable pointer — the tag owner can move it to a different commit at any time, including a malicious one. This is the attack vector used in the tj-actions/changed-files incident (CVE-2025-30066).

Pinning to a full 40-character commit SHA makes the reference immutable. The `# tag` comment preserves human readability so reviewers can tell which version is pinned.

Important: a SHA can also originate from a forked repository. A malicious actor can fork an action, push a compromised commit to the fork, and the SHA will resolve — but it won't exist in the upstream canonical repo. Each SHA in this PR was verified against the action's canonical repository (not a fork).

### Changes

- `actions/checkout@v2` -> `actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0`
  - Version: v2.7.0 | Latest: v6.0.2 | Release age: 89d
  - Commit: https://github.com/actions/checkout/commit/ee0669bd1cc54295c223e0bb666b733df41de1c5

- `actions/upload-artifact@v2` -> `actions/upload-artifact@82c141cc518b40d92cc801eee768e7aafc9c2fa2 # v2.3.1`
  - Version: v2.3.1 | Latest: v3.2.2 | Release age: 22d
  - Commit: https://github.com/actions/upload-artifact/commit/82c141cc518b40d92cc801eee768e7aafc9c2fa2

- `actions/download-artifact@v2` -> `actions/download-artifact@cbed621e49e4c01b044d60f6c80ea4ed6328b281 # v2.1.1`
  - Version: v2.1.1 | Latest: v3.1.0-node20 | Release age: 22d
  - Commit: https://github.com/actions/download-artifact/commit/cbed621e49e4c01b044d60f6c80ea4ed6328b281
  - Warnings: 1 security advisory(ies) found, Action has 1 known advisory(ies)

- `softprops/action-gh-release@v1` -> `softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1`
  - Version: v1 | Latest: v2.6.1 | Release age: 24d
  - Commit: https://github.com/softprops/action-gh-release/commit/de2c0eb89ae2a093876385947365aca7b0e5f844

- `actions/upload-release-asset@v1` -> `actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1.0.2`
  - Version: v1.0.2 | Latest: v1.0.2 | Release age: 2250d
  - Commit: https://github.com/actions/upload-release-asset/commit/e8f9f06c4b078e705bd2ea027f0926603fc9b4d5


### Files modified

- `.github/workflows/release.yaml`

### Security warnings

- 1 security advisory(ies) found
- Action has 1 known advisory(ies)